### PR TITLE
fixing-slide-bug

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -96,7 +96,7 @@ ScrollReveal({
 #services,
 #services .card,
 #testimonials,
-#testimonials .testimony,
+#testimonials .testimony
 #contact,
 #contact .button,
 #contact ul,


### PR DESCRIPTION
O erro era uma vírgula no ScrollReveal, ele estava selecionando o último slide para aparecer junto da sessão "contact" fazendo com que o último slide ficasse com a opacidade zerada, como se fosse uma sessão diferente. A remoção da vírgula resolve o problema.